### PR TITLE
feat: add per-environment browser sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ env_files:
   - .env.local
 
 # Sidecar services (default: none)
-# Supported: postgres, redis
+# Supported: postgres, redis, browser
 services:
   - postgres
   - redis
+  - browser
 ```
 
 See `alpine.yaml.example` for the full template with comments.
@@ -71,7 +72,7 @@ See `alpine.yaml.example` for the full template with comments.
 | `base_image` | `ubuntu:24.04` | Docker image for the dev container |
 | `install` | *(none)* | Shell command to run after cloning |
 | `env_files` | *(none)* | Files to copy from host into `/workspace/` |
-| `services` | *(none)* | Sidecar services: `postgres`, `redis` |
+| `services` | *(none)* | Sidecar services: `postgres`, `redis`, `browser` |
 
 If `alpine.yaml` is missing, Alpine uses defaults and logs a warning.
 
@@ -84,6 +85,7 @@ The generated compose project includes:
 - **Dev container** -- your configured base image with git, curl, SSH, and Claude CLI pre-installed. Runs as a non-root `claude` user with `cap_drop: ALL` and `no-new-privileges`.
 - **PostgreSQL** (if configured) -- `postgres:16` with `trust` auth and tmpfs storage.
 - **Redis** (if configured) -- `redis:7` with persistence disabled.
+- **Browser** (if configured) -- `browserless/chromium:latest` for Playwright/Puppeteer E2E testing. Accessible at `ws://browser:3000` from the dev container via `BROWSER_WS_ENDPOINT`.
 
 **Environment variables** are passed through from the host using Docker's passthrough syntax (no literal values in the generated YAML):
 
@@ -97,10 +99,11 @@ Set these on the host before running `alpine create`. The container inherits the
 
 **Service aliases** for use inside the container:
 
-| Service | Hostname | Port |
-|---|---|---|
-| PostgreSQL | `db` | 5432 |
-| Redis | `cache` | 6379 |
+| Service | Hostname | Port | Env var |
+|---|---|---|---|
+| PostgreSQL | `db` | 5432 | -- |
+| Redis | `cache` | 6379 | -- |
+| Browser | `browser` | 3000 | `BROWSER_WS_ENDPOINT` |
 
 ### Environment Variables
 

--- a/alpine.yaml.example
+++ b/alpine.yaml.example
@@ -20,8 +20,9 @@
 #   - .env
 
 # Services to start alongside the dev container.
-# Supported: postgres, redis
+# Supported: postgres, redis, browser
 # Default: (none)
 # services:
 #   - postgres
 #   - redis
+#   - browser

--- a/cmd/alpine/compose.go
+++ b/cmd/alpine/compose.go
@@ -29,15 +29,20 @@ var serviceDefaults = map[string]ServiceConfig{
 		Healthcheck: "redis-cli ping",
 		ExtraCmd:    `redis-server --save "" --appendonly no`,
 	},
+	"browser": {
+		Image:       "browserless/chromium:latest",
+		Healthcheck: "wget -q --spider http://localhost:3000/json/version",
+	},
 }
 
 // serviceAlias maps service names to their compose service aliases.
 var serviceAlias = map[string]string{
 	"postgres": "db",
 	"redis":    "cache",
+	"browser":  "browser",
 }
 
-// composeTemplate is the Go text/template for generating docker-compose.yml.
+// composeTmpl is the parsed Go text/template for generating docker-compose.yml.
 // Key features:
 //   - Dev service uses build: directive for image building
 //   - SSH agent mount is platform-aware (macOS vs Linux)
@@ -46,7 +51,7 @@ var serviceAlias = map[string]string{
 //   - Tuned health checks (interval: 2s)
 //   - Security hardening: cap_drop ALL, no-new-privileges
 //   - tmpfs with size limits for services that need them
-const composeTemplate = `services:
+var composeTmpl = template.Must(template.New("compose").Parse(`services:
   dev:
     image: {{ .ImageTag }}
     container_name: {{ .Project }}-dev-1
@@ -61,6 +66,9 @@ const composeTemplate = `services:
       - GITHUB_TOKEN
       - GH_TOKEN
       - SSH_AUTH_SOCK={{ .SSHTarget }}
+{{- range .ExtraEnv }}
+      - {{ . }}
+{{- end }}
     labels:
       alpine.managed: "true"
       alpine.name: "{{ .Name }}"
@@ -83,10 +91,10 @@ const composeTemplate = `services:
 {{- range .Services }}
 {{ . }}
 {{- end }}
-`
+`))
 
-// serviceTemplate generates the YAML block for a supporting service.
-const serviceTemplate = `  {{ .Alias }}:
+// serviceTmpl generates the YAML block for a supporting service.
+var serviceTmpl = template.Must(template.New("service").Parse(`  {{ .Alias }}:
     image: {{ .Image }}
 {{- if .ExtraCmd }}
     command: {{ .ExtraCmd }}
@@ -112,7 +120,7 @@ const serviceTemplate = `  {{ .Alias }}:
     labels:
       alpine.managed: "true"
       alpine.name: "{{ .EnvName }}"
-`
+`))
 
 // serviceTemplateData holds data for rendering a service block.
 type serviceTemplateData struct {
@@ -137,6 +145,7 @@ type composeData struct {
 	Created   string
 	Branch    string
 	Services  []string
+	ExtraEnv  []string
 }
 
 // generateComposeYAML produces a docker-compose.yml from the given config.
@@ -167,7 +176,7 @@ func generateComposeYAML(cfg *Config, name, branch, platform, imageTag string) (
 	for _, svc := range cfg.Services {
 		defaults, ok := serviceDefaults[svc]
 		if !ok {
-			return nil, fmt.Errorf("unsupported service: %q (supported: postgres, redis)", svc)
+			return nil, fmt.Errorf("unsupported service: %q (supported: postgres, redis, browser)", svc)
 		}
 		alias := serviceAlias[svc]
 
@@ -180,12 +189,15 @@ func generateComposeYAML(cfg *Config, name, branch, platform, imageTag string) (
 			EnvName:     name,
 		}
 
-		// Determine health check format.
-		// postgres uses CMD-SHELL (pg_isready -U postgres), redis uses CMD with split parts.
-		if svc == "postgres" {
+		// Determine health check format and start period.
+		switch svc {
+		case "postgres":
 			data.UseCMDShell = true
 			data.StartPeriod = "5s"
-		} else {
+		case "browser":
+			data.UseCMDShell = true
+			data.StartPeriod = "10s"
+		default:
 			data.UseCMDShell = false
 			// Split the healthcheck command into JSON array parts for CMD format.
 			parts := strings.Fields(defaults.Healthcheck)
@@ -197,15 +209,19 @@ func generateComposeYAML(cfg *Config, name, branch, platform, imageTag string) (
 			data.StartPeriod = "3s"
 		}
 
-		tmpl, err := template.New("service").Parse(serviceTemplate)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse service template: %w", err)
-		}
 		var buf bytes.Buffer
-		if err := tmpl.Execute(&buf, data); err != nil {
+		if err := serviceTmpl.Execute(&buf, data); err != nil {
 			return nil, fmt.Errorf("failed to render service %q: %w", svc, err)
 		}
 		serviceBlocks = append(serviceBlocks, buf.String())
+	}
+
+	// Inject extra environment variables into the dev container based on enabled services.
+	var extraEnv []string
+	for _, svc := range cfg.Services {
+		if svc == "browser" {
+			extraEnv = append(extraEnv, "BROWSER_WS_ENDPOINT=ws://browser:3000")
+		}
 	}
 
 	data := composeData{
@@ -217,14 +233,11 @@ func generateComposeYAML(cfg *Config, name, branch, platform, imageTag string) (
 		Created:   created,
 		Branch:    branch,
 		Services:  serviceBlocks,
+		ExtraEnv:  extraEnv,
 	}
 
-	tmpl, err := template.New("compose").Parse(composeTemplate)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse compose template: %w", err)
-	}
 	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, data); err != nil {
+	if err := composeTmpl.Execute(&buf, data); err != nil {
 		return nil, fmt.Errorf("failed to render compose YAML: %w", err)
 	}
 

--- a/cmd/alpine/compose.go
+++ b/cmd/alpine/compose.go
@@ -103,8 +103,8 @@ var serviceTmpl = template.Must(template.New("service").Parse(`  {{ .Alias }}:
     tmpfs:
       - {{ .Tmpfs }}
 {{- end }}
-    environment:
 {{- if eq .Alias "db" }}
+    environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
 {{- end }}
     healthcheck:

--- a/cmd/alpine/compose_test.go
+++ b/cmd/alpine/compose_test.go
@@ -91,6 +91,54 @@ func TestGenerateComposeYAML(t *testing.T) {
 		}
 	})
 
+	t.Run("with browser service", func(t *testing.T) {
+		cfg := &Config{BaseImage: "ubuntu:24.04", Services: []string{"browser"}}
+		yaml, err := generateComposeYAML(cfg, "test", "main", "darwin", "alpine-dev:abc")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		s := string(yaml)
+		if !strings.Contains(s, "browser:") {
+			t.Error("browser should produce browser: service block")
+		}
+		if !strings.Contains(s, "browserless/chromium:latest") {
+			t.Error("browser should use browserless/chromium image")
+		}
+		if !strings.Contains(s, "CMD-SHELL") {
+			t.Error("browser healthcheck should use CMD-SHELL")
+		}
+		if !strings.Contains(s, "wget") {
+			t.Error("browser healthcheck should use wget")
+		}
+		if !strings.Contains(s, "start_period: 10s") {
+			t.Error("browser should have 10s start_period")
+		}
+	})
+
+	t.Run("browser injects BROWSER_WS_ENDPOINT into dev", func(t *testing.T) {
+		cfg := &Config{BaseImage: "ubuntu:24.04", Services: []string{"browser"}}
+		yaml, err := generateComposeYAML(cfg, "test", "main", "darwin", "alpine-dev:abc")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		s := string(yaml)
+		if !strings.Contains(s, "BROWSER_WS_ENDPOINT=ws://browser:3000") {
+			t.Error("dev container should have BROWSER_WS_ENDPOINT when browser is enabled")
+		}
+	})
+
+	t.Run("no BROWSER_WS_ENDPOINT without browser", func(t *testing.T) {
+		cfg := &Config{BaseImage: "ubuntu:24.04", Services: []string{"postgres"}}
+		yaml, err := generateComposeYAML(cfg, "test", "main", "darwin", "alpine-dev:abc")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		s := string(yaml)
+		if strings.Contains(s, "BROWSER_WS_ENDPOINT") {
+			t.Error("dev container should NOT have BROWSER_WS_ENDPOINT when browser is not enabled")
+		}
+	})
+
 	t.Run("both services", func(t *testing.T) {
 		cfg := &Config{BaseImage: "ubuntu:24.04", Services: []string{"postgres", "redis"}}
 		yaml, err := generateComposeYAML(cfg, "test", "main", "darwin", "alpine-dev:abc")
@@ -100,6 +148,21 @@ func TestGenerateComposeYAML(t *testing.T) {
 		s := string(yaml)
 		if !strings.Contains(s, "db:") || !strings.Contains(s, "cache:") {
 			t.Error("both service aliases should be present")
+		}
+	})
+
+	t.Run("all three services", func(t *testing.T) {
+		cfg := &Config{BaseImage: "ubuntu:24.04", Services: []string{"postgres", "redis", "browser"}}
+		yaml, err := generateComposeYAML(cfg, "test", "main", "darwin", "alpine-dev:abc")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		s := string(yaml)
+		if !strings.Contains(s, "db:") || !strings.Contains(s, "cache:") || !strings.Contains(s, "browser:") {
+			t.Error("all three service aliases should be present")
+		}
+		if !strings.Contains(s, "BROWSER_WS_ENDPOINT=ws://browser:3000") {
+			t.Error("BROWSER_WS_ENDPOINT should be injected with all three services")
 		}
 	})
 

--- a/cmd/alpine/config.go
+++ b/cmd/alpine/config.go
@@ -20,6 +20,7 @@ type Config struct {
 var validServices = map[string]bool{
 	"postgres": true,
 	"redis":    true,
+	"browser":  true,
 }
 
 // loadConfig reads and validates alpine.yaml from the current directory.
@@ -55,7 +56,7 @@ func (c *Config) validate() error {
 	}
 	for _, svc := range c.Services {
 		if !validServices[svc] {
-			return fmt.Errorf("unknown service %q (supported: postgres, redis)", svc)
+			return fmt.Errorf("unknown service %q (supported: postgres, redis, browser)", svc)
 		}
 	}
 	return nil

--- a/cmd/alpine/config_test.go
+++ b/cmd/alpine/config_test.go
@@ -35,6 +35,11 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: "base_image cannot be empty",
 		},
 		{
+			name:      "valid browser service",
+			yaml:      "base_image: ubuntu:24.04\nservices:\n  - browser\n",
+			wantImage: "ubuntu:24.04",
+		},
+		{
 			name:    "unknown service",
 			yaml:    "base_image: ubuntu:24.04\nservices:\n  - mysql\n",
 			wantErr: "unknown service",
@@ -104,8 +109,16 @@ func TestValidate(t *testing.T) {
 			cfg:  Config{BaseImage: "ubuntu:24.04", Services: []string{"redis"}},
 		},
 		{
+			name: "valid browser",
+			cfg:  Config{BaseImage: "ubuntu:24.04", Services: []string{"browser"}},
+		},
+		{
 			name: "both services",
 			cfg:  Config{BaseImage: "ubuntu:24.04", Services: []string{"postgres", "redis"}},
+		},
+		{
+			name: "all three services",
+			cfg:  Config{BaseImage: "ubuntu:24.04", Services: []string{"postgres", "redis", "browser"}},
 		},
 		{
 			name: "no services",


### PR DESCRIPTION
## Summary

- Add `browser` as a supported service in `alpine.yaml` that spins up a `browserless/chromium` sidecar container
- Inject `BROWSER_WS_ENDPOINT=ws://browser:3000` into the dev container when browser is enabled
- Parse compose templates once at package init via `template.Must` instead of re-parsing per call, removing unreachable error branches

## Changes

- **`config.go`**: Add `browser` to `validServices`
- **`compose.go`**: Add browser to `serviceDefaults`/`serviceAlias`, inject `BROWSER_WS_ENDPOINT` into dev env, use `template.Must` for pre-parsed templates
- **`compose_test.go`**: 4 new test cases (browser service generation, endpoint injection, no endpoint without browser, all three services)
- **`config_test.go`**: 3 new test cases (browser in loadConfig, validate, all three services)
- **`README.md`** / **`alpine.yaml.example`**: Document browser service

## Test plan

- [x] `make test` passes (97.3% coverage)
- [ ] Verify `services: [browser]` in `alpine.yaml` produces a compose file with the browser sidecar
- [ ] Verify `BROWSER_WS_ENDPOINT` appears in dev container only when browser is enabled
- [ ] Verify existing postgres/redis behavior is unchanged

Closes #10