### PR TITLE
Add basic sprite-opencode CLI wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX ?= $(HOME)/.local
 BINDIR ?= $(PREFIX)/bin
-CLI_NAME := sprite-opencode
+CLI_NAME := sc
 
 .PHONY: help install uninstall
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+PREFIX ?= $(HOME)/.local
+BINDIR ?= $(PREFIX)/bin
+CLI_NAME := sprite-opencode
+
+.PHONY: help install uninstall
+
+help:
+	@printf 'Targets:\n'
+	@printf '  make install   Install $(CLI_NAME) into $(BINDIR)\n'
+	@printf '  make uninstall Remove $(BINDIR)/$(CLI_NAME)\n'
+
+install:
+	@mkdir -p "$(BINDIR)"
+	@ln -sfn "$(CURDIR)/$(CLI_NAME)" "$(BINDIR)/$(CLI_NAME)"
+	@printf 'Installed %s -> %s\n' "$(BINDIR)/$(CLI_NAME)" "$(CURDIR)/$(CLI_NAME)"
+
+uninstall:
+	@rm -f "$(BINDIR)/$(CLI_NAME)"
+	@printf 'Removed %s\n' "$(BINDIR)/$(CLI_NAME)"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sprite OpenCode Setup
 
-`sprite-opencode` is a basic CLI that creates a ready-to-code Sprite environment for the current repository.
+`sc` is a basic CLI that creates a ready-to-code Sprite environment for the current repository.
 
 ## What it does
 
@@ -24,24 +24,24 @@
 ## Usage
 
 ```bash
-./sprite-opencode setup --branch <branch-name> [--org <org-name>]
-./sprite-opencode --branch <branch-name> [--org <org-name>]
-./sprite-opencode install
-./sprite-opencode version
+./sc setup --branch <branch-name> [--org <org-name>]
+./sc --branch <branch-name> [--org <org-name>]
+./sc install
+./sc version
 ```
 
 Install globally with Make:
 
 ```bash
 make install
-sprite-opencode --help
+sc --help
 ```
 
 Examples:
 
 ```bash
-./sprite-opencode setup --branch feat/my-change
-./sprite-opencode setup --branch fix/login-timeout --org my-org
+./sc setup --branch feat/my-change
+./sc setup --branch fix/login-timeout --org my-org
 ```
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sprite OpenCode Setup
 
-`setup-sprite-opencode.sh` creates a ready-to-code Sprite environment for the current repository.
+`sprite-opencode` is a basic CLI that creates a ready-to-code Sprite environment for the current repository.
 
 ## What it does
 
@@ -24,18 +24,28 @@
 ## Usage
 
 ```bash
-./setup-sprite-opencode.sh --branch <branch-name> [--org <org-name>]
+./sprite-opencode setup --branch <branch-name> [--org <org-name>]
+./sprite-opencode --branch <branch-name> [--org <org-name>]
+./sprite-opencode install
+./sprite-opencode version
+```
+
+Install globally with Make:
+
+```bash
+make install
+sprite-opencode --help
 ```
 
 Examples:
 
 ```bash
-./setup-sprite-opencode.sh --branch feat/my-change
-./setup-sprite-opencode.sh --branch fix/login-timeout --org my-org
+./sprite-opencode setup --branch feat/my-change
+./sprite-opencode setup --branch fix/login-timeout --org my-org
 ```
 
 ## Notes
 
-- Run the script from inside the git repository you want to clone into Sprite.
+- Run the CLI from inside the git repository you want to clone into Sprite.
 - `--branch` is required.
 - If `expect` is installed, the script auto-enters `sprite console`; otherwise it falls back to direct `sprite exec` launch.

--- a/sc
+++ b/sc
@@ -13,7 +13,7 @@ setup_script="$script_dir/setup-sprite-opencode.sh"
 
 usage() {
   cat <<'EOF'
-Usage: sprite-opencode <command> [options]
+Usage: sc <command> [options]
 
 Commands:
   setup   Create and open a Sprite OpenCode environment
@@ -26,22 +26,22 @@ Setup options:
   -o, --org <org-name>        Sprite organization name
 
 Examples:
-  ./sprite-opencode setup --branch feat/my-change
-  ./sprite-opencode setup --branch fix/login-timeout --org my-org
-  ./sprite-opencode install
-  ./sprite-opencode version
+  ./sc setup --branch feat/my-change
+  ./sc setup --branch fix/login-timeout --org my-org
+  ./sc install
+  ./sc version
 EOF
 }
 
 version() {
-  printf 'sprite-opencode 0.1.0\n'
+  printf 'sc 0.1.0\n'
 }
 
 install_local() {
   local bin_dir target real_script
   bin_dir="$HOME/.local/bin"
-  target="$bin_dir/sprite-opencode"
-  real_script="$script_dir/sprite-opencode"
+  target="$bin_dir/sc"
+  real_script="$script_dir/sc"
 
   mkdir -p "$bin_dir"
   ln -sfn "$real_script" "$target"

--- a/sprite-opencode
+++ b/sprite-opencode
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_path="${BASH_SOURCE[0]}"
+while [[ -L "$source_path" ]]; do
+  link_dir="$(cd "$(dirname "$source_path")" && pwd)"
+  source_path="$(readlink "$source_path")"
+  [[ "$source_path" != /* ]] && source_path="$link_dir/$source_path"
+done
+
+script_dir="$(cd "$(dirname "$source_path")" && pwd)"
+setup_script="$script_dir/setup-sprite-opencode.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: sprite-opencode <command> [options]
+
+Commands:
+  setup   Create and open a Sprite OpenCode environment
+  install Install CLI into ~/.local/bin
+  version Show CLI version
+  help    Show this help
+
+Setup options:
+  -b, --branch <branch-name>  Branch to check out/create inside sprite (required)
+  -o, --org <org-name>        Sprite organization name
+
+Examples:
+  ./sprite-opencode setup --branch feat/my-change
+  ./sprite-opencode setup --branch fix/login-timeout --org my-org
+  ./sprite-opencode install
+  ./sprite-opencode version
+EOF
+}
+
+version() {
+  printf 'sprite-opencode 0.1.0\n'
+}
+
+install_local() {
+  local bin_dir target real_script
+  bin_dir="$HOME/.local/bin"
+  target="$bin_dir/sprite-opencode"
+  real_script="$script_dir/sprite-opencode"
+
+  mkdir -p "$bin_dir"
+  ln -sfn "$real_script" "$target"
+  printf 'Installed: %s -> %s\n' "$target" "$real_script"
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 0
+fi
+
+command="$1"
+shift
+
+case "$command" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  -v|--version)
+    version
+    exit 0
+    ;;
+esac
+
+if [[ "$command" == -* ]]; then
+  set -- "$command" "$@"
+  command="setup"
+fi
+
+if [[ ! -f "$setup_script" ]]; then
+  printf 'Missing setup script: %s\n' "$setup_script" >&2
+  exit 1
+fi
+
+case "$command" in
+  setup)
+    exec "$setup_script" "$@"
+    ;;
+  install)
+    install_local
+    ;;
+  version|--version|-v)
+    version
+    ;;
+  help|-h|--help)
+    usage
+    ;;
+  *)
+    printf "Unknown command: %s\n\n" "$command" >&2
+    usage >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add a minimal `sprite-opencode` CLI entrypoint that wraps the existing setup workflow
- support basic CLI ergonomics (`help`, `version`, `install`) plus direct flag usage for setup
- update README usage and add a Makefile install/uninstall flow for global command access
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/backland-labs/alpine/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
