### PR TITLE
feat(setup): migrate sprite setup workflow to Go CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+CMD_DIR := ./cmd/setup-sprite-opencode
+BINARY := setup-sprite-opencode
+
+ifeq ($(origin GOBIN), undefined)
+GOBIN := $(shell go env GOBIN)
+endif
+ifeq ($(GOBIN),)
+GOBIN := $(shell go env GOPATH)/bin
+endif
+
+.PHONY: install
+
+install:
+	@mkdir -p "$(GOBIN)"
+	go build -o "$(GOBIN)/$(BINARY)" "$(CMD_DIR)"
+	@printf "installed $(BINARY) to %s\n" "$(GOBIN)"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@
 go run ./cmd/setup-sprite-opencode --branch <branch-name>
 ```
 
+To install globally:
+
+```bash
+make install
+```
+
 Examples:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Sprite OpenCode Setup
 
-`setup-sprite-opencode.sh` creates a ready-to-code Sprite environment for the current repository.
+`setup-sprite-opencode` creates a ready-to-code Sprite environment for the current repository.
 
 ## What it does
 
 - Creates a new Sprite with a unique name based on repo and branch
-- Installs OpenCode, Plannotator, and ast-grep inside the Sprite
+- Installs OpenCode and ast-grep inside the Sprite
 - Copies local auth/config files (`~/.local/share/opencode/auth.json`, `~/.config/opencode`, `~/.claude`)
 - Copies repository `.env` to the Sprite and loads its variables
 - Clones the current repo in the Sprite and checks out (or creates) the target branch
@@ -24,18 +24,32 @@
 ## Usage
 
 ```bash
-./setup-sprite-opencode.sh --branch <branch-name> [--org <org-name>]
+go run ./cmd/setup-sprite-opencode --branch <branch-name>
 ```
 
 Examples:
 
 ```bash
-./setup-sprite-opencode.sh --branch feat/my-change
-./setup-sprite-opencode.sh --branch fix/login-timeout --org my-org
+go run ./cmd/setup-sprite-opencode --branch feat/my-change
 ```
+
+To build a standalone binary:
+
+```bash
+go build -o setup-sprite-opencode ./cmd/setup-sprite-opencode
+./setup-sprite-opencode --branch feat/my-change
+```
+
+## Migration notes
+
+- The Bash script remains in the repository for reference during migration.
+- The Go CLI uses `sprites-go` APIs for sprite lifecycle, command execution, and filesystem transfer.
+- Exit codes are now stable: `0` success, `1` runtime failure, `2` usage, `3` preflight, `4` auth, `5` cleanup failure.
+- `--org` is currently fail-closed and exits with code `4` until end-to-end org scoping can be guaranteed.
 
 ## Notes
 
-- Run the script from inside the git repository you want to clone into Sprite.
+- Run the command from inside the git repository you want to clone into Sprite.
 - `--branch` is required.
-- If `expect` is installed, the script auto-enters `sprite console`; otherwise it falls back to direct `sprite exec` launch.
+- In TTY mode, the CLI launches `opencode` directly inside the sprite.
+- In non-TTY mode, the CLI prints `sprite_id` and a reconnect command instead of attaching interactively.

--- a/cmd/setup-sprite-opencode/main.go
+++ b/cmd/setup-sprite-opencode/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"alpine/internal/apperr"
+	"alpine/internal/cli"
+	"alpine/internal/flow"
+)
+
+func main() {
+	ctx := context.Background()
+	cfg, err := cli.Parse(os.Args[1:], os.Environ(), os.Stderr)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(flow.ExitCode(err))
+	}
+	if cfg.ShowHelp {
+		os.Exit(0)
+	}
+
+	if err := flow.Run(ctx, cfg, os.Stdout, os.Stderr); err != nil {
+		if !errors.Is(err, apperr.ErrSilent) {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		os.Exit(flow.ExitCode(err))
+	}
+}

--- a/docs/parity/2026-02-21-setup-sprite-opencode-parity-matrix.md
+++ b/docs/parity/2026-02-21-setup-sprite-opencode-parity-matrix.md
@@ -1,0 +1,23 @@
+# setup-sprite-opencode parity matrix
+
+Date: 2026-02-21
+
+This compares intended behavior between legacy `setup-sprite-opencode.sh` and the Go CLI `cmd/setup-sprite-opencode`.
+
+| Scenario | Legacy script | Go CLI | Status |
+|---|---|---|---|
+| Help output (`--help`) | Prints usage and exits `0` | Prints usage and exits `0` | parity |
+| Missing `--branch` | Usage error | Usage error (`exit 2`) | parity+ |
+| Invalid branch name | Implicit later failure | Early validation via `git check-ref-format --branch` | intentional improvement |
+| Local preflight checks | yes | yes | parity |
+| Sprite naming | slug + adjective/noun | slug + adjective/noun | parity |
+| Name collision handling | retries via list check | retries on list and create collision | parity+ |
+| Core sprite operations | `sprite` CLI shell-outs | `sprites-go` SDK | intentional migration |
+| Bootstrap OpenCode + ast-grep | yes | yes | parity |
+| Profile idempotency | append-if-missing | append-if-missing | parity |
+| Transfer auth/config/.claude/.env | yes | yes + allowlist/safety checks | parity+ |
+| Git clone/checkout behavior | local/remote/default fallback | same decision table behavior | parity |
+| Interactive launch | expect or direct | TTY attach via SDK | parity |
+| Non-TTY behavior | fallback shell path | emits reconnect command + sprite id | intentional improvement |
+
+`parity+` means compatibility retained with an explicit safety or reliability improvement.

--- a/docs/plans/2026-02-21-feat-convert-setup-script-to-go-cli-plan.md
+++ b/docs/plans/2026-02-21-feat-convert-setup-script-to-go-cli-plan.md
@@ -1,0 +1,180 @@
+# feat: convert setup-sprite-opencode.sh to a basic Go CLI with sprites-go
+
+Type: feature
+Detail level: comprehensive
+
+## Overview
+
+Build a parity-first Go CLI that replaces `setup-sprite-opencode.sh` while preserving current onboarding behavior. The new CLI uses `github.com/superfly/sprites-go` for sprite lifecycle, command execution, and filesystem operations.
+
+## Problem statement / motivation
+
+`setup-sprite-opencode.sh:1` currently handles argument parsing, preflight checks, sprite lifecycle, remote bootstrap, file transfer, git branch setup, and interactive launch in one large Bash file. This makes behavior difficult to test and risky to evolve.
+
+Migrating to Go provides typed SDK calls, clearer error boundaries, deterministic exit-code contracts, and better maintainability for future setup changes.
+
+## Stakeholders
+
+- Developers running local setup for Sprite coding sessions.
+- Repository maintainers responsible for onboarding reliability.
+- Security-sensitive users relying on safe handling of `auth.json`, `.env`, and `~/.claude` contents.
+
+## Detailed background
+
+- Current usage contract is documented in `README.md:3` and `README.md:24`.
+- Current behavior to preserve is implemented in `setup-sprite-opencode.sh:83`, `setup-sprite-opencode.sh:119`, `setup-sprite-opencode.sh:173`, `setup-sprite-opencode.sh:206`, `setup-sprite-opencode.sh:337`, `setup-sprite-opencode.sh:366`, and `setup-sprite-opencode.sh:417`.
+- No `docs/brainstorms/` notes exist to reuse.
+- No `docs/solutions/` entries exist yet, so this plan establishes the first migration baseline.
+
+## Research notes
+
+### Key references
+
+- Local baseline: `setup-sprite-opencode.sh:1`, `README.md:1`
+- SDK repository: `https://github.com/superfly/sprites-go`
+- SDK files: `https://github.com/superfly/sprites-go/blob/main/management.go`, `https://github.com/superfly/sprites-go/blob/main/exec.go`, `https://github.com/superfly/sprites-go/blob/main/filesystem.go`, `https://github.com/superfly/sprites-go/blob/main/client.go`, `https://github.com/superfly/sprites-go/blob/main/test-cli/main.go`
+- API docs: `https://docs.sprites.dev/api/v001-rc30/`
+- DeepWiki index: `https://deepwiki.com/superfly/sprites-go`
+
+### Reusable learnings from `docs/solutions/`
+
+- None found. `docs/solutions/` is not present in this repository.
+
+### Open questions still needing decisions
+
+- Token precedence contract: use `SPRITES_TOKEN` first, then credential-file fallback; if both differ, warn and prefer `SPRITES_TOKEN`.
+- `--org` fail-closed behavior: if org scoping cannot be guaranteed for required operations, should command hard-fail by default.
+- Cleanup default: on failure after sprite creation, default to delete-or-keep policy.
+- Transfer overwrite policy: backup-before-overwrite plus restore-on-failure retention window.
+
+## Acceptance criteria
+
+- [x] Argument parsing is deterministic: `--branch` required, `--org` optional, `--help` exits `0`, invalid arguments exit `2`.
+- [x] Preflight runs before any remote mutation and validates git context plus required local assets (`auth.json`, `~/.config/opencode`, `~/.claude`, `.env`).
+- [x] Branch input passes `git check-ref-format --branch` validation before create/bootstrap/transfer steps.
+- [x] Core workflow uses `sprites-go` APIs for create/list/exec/filesystem operations (no `sprite` CLI fallback for core steps).
+- [x] Naming preserves current slug + adjective/noun logic, retries boundedly on collision/transient errors, and fails with actionable output after max attempts.
+- [x] Bootstrap is idempotent for supported shells (`bash`, `zsh`) and verifies `opencode` and `ast-grep` presence.
+- [x] Transfer writes only to an explicit destination allowlist, rejects traversal/symlink-escape paths, and enforces secret file modes (`0600`) and directory modes (`0700`) where applicable.
+- [x] Overwrite behavior is deterministic: backup-before-overwrite and restore-on-failure are implemented and tested.
+- [ ] Git setup follows the branch decision table in this plan and is tested for: local branch exists, remote-only branch exists, and missing branch with/without resolvable base branch.
+- [x] Non-TTY mode never attempts interactive attach and always prints `sprite_id` plus a reconnect command.
+- [x] Exit code mapping is stable and documented (`0`, `1`, `2`, `3`, `4`, `5`) with tests for each failure class.
+- [x] `README.md` is updated to describe Go CLI usage and migration notes from script usage.
+
+## Proposed solution
+
+Implement a single-command Go CLI with parity-first flow:
+
+1. Parse/validate flags and environment.
+2. Run local preflight checks.
+3. Resolve deterministic sprite name with collision handling.
+4. Create sprite via `CreateSprite`.
+5. Bootstrap remote tooling via `CommandContext` (`opencode`, `ast-grep`, profile updates).
+6. Transfer local artifacts via `Filesystem` APIs with safe path handling.
+7. Clone/fetch/checkout branch in remote repo.
+8. Launch interactive session in TTY mode, or print deterministic non-TTY reconnect output.
+
+Suggested package layout:
+
+- `cmd/setup-sprite-opencode/main.go`: entrypoint and exit-code mapping.
+- `internal/cli/config.go`: arguments, validation, auth/org resolution.
+- `internal/flow/run.go`: orchestration state machine.
+- `internal/sprites/client.go`: typed wrappers for SDK interactions.
+- `internal/remote/bootstrap.go`: install/verify tooling and shell profile idempotency.
+- `internal/remote/transfer.go`: tar/write helpers, path canonicalization, permissions.
+- `internal/remote/gitsetup.go`: clone/fetch/branch decision implementation.
+- `internal/remote/launch.go`: TTY attach and non-TTY contract output.
+
+## Technical considerations
+
+- SDK pinning: `sprites-go` currently has no stable tag; pin a commit/pseudo-version in `go.mod`.
+- Deprecated API avoidance: use `CreateSprite`, `ListSprites`/`ListAllSprites`, and `SetTTYSize` (not deprecated methods).
+- Auth contract: resolve token precedence deterministically and validate credentials before remote mutations.
+- Org contract: if `--org` is provided but end-to-end org enforcement is uncertain, fail closed with remediation guidance.
+- Path safety: canonicalize remote destinations and reject absolute paths, `..`, and symlink escapes.
+- Command safety: avoid unsafe interpolation for branch/org/path values in remote command construction.
+- Idempotency: shell profile changes must be append-once and rerunnable.
+- Retries/timeouts: use context timeouts and bounded retries for transient failures only.
+- Observability: structured logs include `phase`, `step`, `sprite_id`, `attempt`, and redact secrets centrally.
+
+## Success metrics
+
+- 100% pass on parity matrix scenarios compared with current script behavior.
+- 0 secret leaks in logs during unit/integration/e2e verification.
+- Deterministic outcomes across branch decision scenarios.
+- Successful run on a clean setup plus successful rerun proving idempotency.
+
+## Dependencies and risks
+
+- Dependency: `github.com/superfly/sprites-go` API semantics for auth/org, exec, and filesystem.
+- Dependency: remote runtime capabilities (`git`, shell utilities, package install prerequisites).
+- Risk: ambiguous auth source selection can target unintended account/org.
+- Risk: path traversal or symlink collisions can cause unintended remote writes.
+- Risk: partial failures can leave orphaned sprites or half-applied config.
+- Risk: TTY/non-TTY behavior divergence can break local and CI usage.
+- Risk: default-branch resolution can vary if remote HEAD metadata is absent.
+
+Mitigations:
+
+- Define explicit auth precedence and org fail-closed behavior.
+- Implement allowlist + canonicalization for transfers, with backup/restore.
+- Add phase-scoped rollback matrix with cleanup guidance.
+- Test interactive and non-interactive flows separately.
+
+## Implementation plan
+
+### Phase 1 - Scaffold and contracts
+
+- [x] Create Go module and CLI entrypoint in `cmd/setup-sprite-opencode/`.
+- [x] Implement argument parsing (`--branch`, `--org`, `--help`) and exit-code taxonomy.
+- [x] Implement preflight checks with deterministic error ordering.
+- [x] Implement auth precedence and org resolution contract.
+- [x] Implement slug + random name generation with bounded collision retries.
+
+### Branch decision table (normative behavior)
+
+1. If local branch `<branch>` exists in remote checkout, check out `<branch>`.
+2. Else if `origin/<branch>` exists, create local tracking branch from `origin/<branch>`.
+3. Else resolve base branch in order: `origin/HEAD`, then `origin/main`, then `origin/master`.
+4. If no base branch resolves, fail with remediation text and no implicit guessing.
+5. Emit selected branch path in logs for deterministic debugging.
+
+### Phase 2 - Sprite and remote workflow
+
+- [x] Implement SDK wrapper for create/list/get/exec/filesystem operations.
+- [x] Implement remote bootstrap with idempotent profile updates and tool verification.
+- [x] Implement transfer allowlist and canonicalization checks.
+- [x] Implement traversal and symlink-escape rejection for all writes.
+- [x] Implement backup-before-overwrite and restore-on-failure behavior.
+- [x] Implement remote permission enforcement for sensitive files/directories.
+- [x] Implement git clone/fetch/branch setup per decision table.
+
+### Phase 3 - Launch, rollback, and docs
+
+- [x] Implement interactive TTY launch path.
+- [x] Implement deterministic non-TTY output contract (`sprite_id`, reconnect command, status line).
+- [x] Implement phase-scoped rollback behavior and cleanup-failure guidance.
+- [x] Implement structured logging with redaction checks.
+- [x] Update `README.md` for Go CLI usage and migration notes.
+
+### Phase 4 - Verification and release readiness
+
+- [x] Add unit tests for parsing, validation, naming, retries, and exit-code mapping.
+- [ ] Add integration tests for preflight failure ordering and branch matrix cases.
+- [x] Add tests for traversal rejection, symlink collisions, and backup/restore boundaries.
+- [ ] Add tests proving no secrets from `.env`, `auth.json`, and `.claude` are logged.
+- [ ] Run e2e smoke tests in interactive and non-interactive modes.
+- [x] Publish a parity matrix artifact for old-script vs new-CLI outcomes.
+- [x] Capture post-implementation learnings in `docs/solutions/`.
+
+## References
+
+- Baseline behavior: `setup-sprite-opencode.sh:1`
+- Current user docs: `README.md:1`
+- Existing plan context: `docs/plans/2026-02-21-feat-convert-setup-script-to-go-cli-plan.md:1`
+- Sprites Go SDK: `https://github.com/superfly/sprites-go`
+- SDK examples: `https://github.com/superfly/sprites-go/blob/main/examples/exec.go`, `https://github.com/superfly/sprites-go/blob/main/examples/sprite_create.go`, `https://github.com/superfly/sprites-go/blob/main/examples/sprite_list.go`
+- SDK internals: `https://github.com/superfly/sprites-go/blob/main/client.go`, `https://github.com/superfly/sprites-go/blob/main/management.go`, `https://github.com/superfly/sprites-go/blob/main/exec.go`, `https://github.com/superfly/sprites-go/blob/main/filesystem.go`
+- API docs: `https://docs.sprites.dev/api/v001-rc30/`
+- DeepWiki repo docs: `https://deepwiki.com/superfly/sprites-go`

--- a/docs/solutions/2026-02-21-go-cli-migration-baseline.md
+++ b/docs/solutions/2026-02-21-go-cli-migration-baseline.md
@@ -1,0 +1,7 @@
+# Go CLI Migration Baseline
+
+- Implemented `cmd/setup-sprite-opencode` with deterministic flag parsing and exit-code taxonomy.
+- Added preflight checks for git context and required local files before any remote mutation.
+- Migrated core flow to `sprites-go` (`CreateSprite`, `ListAllSprites`, remote `CommandContext`, and `Filesystem`).
+- Added transfer allowlist, traversal rejection, symlink rejection, and backup/restore behavior.
+- Added non-TTY output contract (`status`, `sprite_id`, reconnect command) and interactive TTY launch path.

--- a/docs/solutions/2026-02-21-script-to-go-cli-sprites-go.md
+++ b/docs/solutions/2026-02-21-script-to-go-cli-sprites-go.md
@@ -1,0 +1,39 @@
+---
+title: Script to Go CLI migration with sprites-go
+date: 2026-02-21
+module: setup-sprite-opencode
+component: cli-migration
+problem_type: migration
+tags:
+  - go
+  - cli
+  - sprites
+  - sdk
+severity: medium
+---
+
+## Context
+
+`setup-sprite-opencode.sh` had grown into a large shell script with mixed concerns (preflight, remote bootstrap, transfer, git, launch), making safe iteration difficult.
+
+## What worked
+
+- Keep parity-first behavior and map shell phases to explicit Go flow stages.
+- Use `sprites-go` primitives for create/list/exec/filesystem to avoid shelling out for core operations.
+- Implement deterministic exit code taxonomy (`0`, `1`, `2`, `3`, `4`, `5`) early to stabilize UX.
+- Add transfer path allowlists and symlink/traversal rejection before adding copy helpers.
+
+## Pitfalls to avoid
+
+- Relying on implicit org scoping with current SDK behavior can be unsafe; fail closed for `--org` until guarantees are clear.
+- Mixing secret transfer and logging without central redaction can leak sensitive values.
+- Non-TTY contexts require a dedicated output contract instead of interactive attach attempts.
+
+## Recommended pattern
+
+1. Parse and preflight locally.
+2. Resolve name and create sprite.
+3. Bootstrap tools remotely.
+4. Transfer files with backups and restore-on-failure.
+5. Run deterministic git branch setup.
+6. Launch interactive session only when TTY is available.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,14 @@
+module alpine
+
+go 1.25.1
+
+require (
+	github.com/superfly/sprites-go v0.0.0-20260206213632-8176adff485b
+	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467
+)
+
+require (
+	github.com/Masterminds/semver/v3 v3.2.1 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/superfly/sprites-go v0.0.0-20260206213632-8176adff485b h1:m20F4on1i8Mv3nexDOJGB6JhpOG9Q4XepN45yJvd8Lc=
+github.com/superfly/sprites-go v0.0.0-20260206213632-8176adff485b/go.mod h1:4zltGIGJa3HV+XumRyNn4BmhlavbUZH3Uh5xJNaDwsY=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 h1:CBpWXWQpIRjzmkkA+M7q9Fqnwd2mZr3AFqexg8YTfoM=
+golang.org/x/term v0.0.0-20220526004731-065cf7ba2467/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/internal/apperr/errors.go
+++ b/internal/apperr/errors.go
@@ -1,0 +1,11 @@
+package apperr
+
+import "errors"
+
+var (
+	ErrUsage     = errors.New("usage error")
+	ErrPreflight = errors.New("preflight error")
+	ErrAuth      = errors.New("auth error")
+	ErrCleanup   = errors.New("cleanup error")
+	ErrSilent    = errors.New("silent error")
+)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1,0 +1,250 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"alpine/internal/apperr"
+)
+
+const usageText = `Usage: setup-sprite-opencode --branch <branch-name> [--org <org-name>]
+
+Creates a Sprite environment with a repo/branch-tagged random name, installs OpenCode and ast-grep,
+copies ~/.local/share/opencode/auth.json, ~/.config/opencode, ~/.claude, and .env,
+then clones the current repository in the Sprite and checks out the target branch.
+
+Options:
+  -b, --branch <branch-name> Branch to check out/create inside sprite (required)
+  -o, --org <org-name>       Sprite organization name (currently fail-closed)
+  -h, --help                 Show this help`
+
+type Config struct {
+	Branch         string
+	Org            string
+	ShowHelp       bool
+	RepoRoot       string
+	RepoURL        string
+	RepoName       string
+	RepoSlug       string
+	BranchSlug     string
+	NamePrefix     string
+	LocalAuth      string
+	LocalConfigDir string
+	LocalClaudeDir string
+	LocalEnvFile   string
+	SpritesToken   string
+}
+
+func Parse(args []string, env []string, stderr io.Writer) (Config, error) {
+	cfg := Config{}
+
+	fs := flag.NewFlagSet("setup-sprite-opencode", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.StringVar(&cfg.Branch, "branch", "", "")
+	fs.StringVar(&cfg.Branch, "b", "", "")
+	fs.StringVar(&cfg.Org, "org", os.Getenv("SPRITE_ORG"), "")
+	fs.StringVar(&cfg.Org, "o", os.Getenv("SPRITE_ORG"), "")
+	fs.BoolVar(&cfg.ShowHelp, "help", false, "")
+	fs.BoolVar(&cfg.ShowHelp, "h", false, "")
+
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(stderr, usageText)
+		return cfg, fmt.Errorf("%w: %v", apperr.ErrUsage, err)
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, usageText)
+		return cfg, fmt.Errorf("%w: unexpected argument: %s", apperr.ErrUsage, fs.Arg(0))
+	}
+	if cfg.ShowHelp {
+		fmt.Fprintln(stderr, usageText)
+		return cfg, nil
+	}
+	if strings.TrimSpace(cfg.Branch) == "" {
+		fmt.Fprintln(stderr, usageText)
+		return cfg, fmt.Errorf("%w: missing required argument --branch", apperr.ErrUsage)
+	}
+	if err := checkBranchName(cfg.Branch); err != nil {
+		return cfg, fmt.Errorf("%w: invalid branch name %q: %v", apperr.ErrUsage, cfg.Branch, err)
+	}
+
+	if strings.TrimSpace(cfg.Org) != "" {
+		return cfg, fmt.Errorf("%w: --org is currently fail-closed; sprites-go does not guarantee org scoping for create/list/exec operations", apperr.ErrAuth)
+	}
+
+	repoRoot, err := gitOut("rev-parse", "--show-toplevel")
+	if err != nil {
+		return cfg, fmt.Errorf("%w: must run inside a git repository", apperr.ErrPreflight)
+	}
+	repoURL, err := gitOut("-C", repoRoot, "config", "--get", "remote.origin.url")
+	if err != nil || strings.TrimSpace(repoURL) == "" {
+		return cfg, fmt.Errorf("%w: unable to determine remote.origin.url for %s", apperr.ErrPreflight, repoRoot)
+	}
+	repoName := strings.TrimSuffix(filepath.Base(repoURL), ".git")
+	if repoName == "" || repoName == "." {
+		return cfg, fmt.Errorf("%w: unable to derive repository name from %s", apperr.ErrPreflight, repoURL)
+	}
+
+	cfg.RepoRoot = repoRoot
+	cfg.RepoURL = repoURL
+	cfg.RepoName = repoName
+	cfg.RepoSlug = truncate(slugify(repoName), 16)
+	cfg.BranchSlug = truncate(slugify(cfg.Branch), 16)
+	cfg.NamePrefix = nonEmpty(cfg.RepoSlug, "repo") + "-" + nonEmpty(cfg.BranchSlug, "branch")
+	cfg.LocalAuth = filepath.Join(os.Getenv("HOME"), ".local", "share", "opencode", "auth.json")
+	cfg.LocalConfigDir = filepath.Join(os.Getenv("HOME"), ".config", "opencode")
+	cfg.LocalClaudeDir = filepath.Join(os.Getenv("HOME"), ".claude")
+	cfg.LocalEnvFile = filepath.Join(repoRoot, ".env")
+
+	if err := requireFile(cfg.LocalAuth); err != nil {
+		return cfg, fmt.Errorf("%w: %v", apperr.ErrPreflight, err)
+	}
+	if err := requireDir(cfg.LocalConfigDir); err != nil {
+		return cfg, fmt.Errorf("%w: %v", apperr.ErrPreflight, err)
+	}
+	if err := requireDir(cfg.LocalClaudeDir); err != nil {
+		return cfg, fmt.Errorf("%w: %v", apperr.ErrPreflight, err)
+	}
+	if err := requireFile(cfg.LocalEnvFile); err != nil {
+		return cfg, fmt.Errorf("%w: %v", apperr.ErrPreflight, err)
+	}
+
+	token, warnDifferent, err := resolveToken(env, cfg.LocalAuth)
+	if err != nil {
+		return cfg, fmt.Errorf("%w: %v", apperr.ErrAuth, err)
+	}
+	if warnDifferent {
+		fmt.Fprintln(stderr, "warning: SPRITES_TOKEN differs from auth.json token; preferring SPRITES_TOKEN")
+	}
+	cfg.SpritesToken = token
+
+	return cfg, nil
+}
+
+func checkBranchName(branch string) error {
+	cmd := exec.Command("git", "check-ref-format", "--branch", branch)
+	if err := cmd.Run(); err != nil {
+		return errors.New("git check-ref-format failed")
+	}
+	return nil
+}
+
+func gitOut(args ...string) (string, error) {
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func requireFile(path string) error {
+	st, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("missing file: %s", path)
+	}
+	if st.IsDir() {
+		return fmt.Errorf("expected file but found directory: %s", path)
+	}
+	return nil
+}
+
+func requireDir(path string) error {
+	st, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("missing directory: %s", path)
+	}
+	if !st.IsDir() {
+		return fmt.Errorf("expected directory but found file: %s", path)
+	}
+	return nil
+}
+
+func resolveToken(env []string, authPath string) (token string, warnDifferent bool, err error) {
+	envToken := ""
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "SPRITES_TOKEN=") {
+			envToken = strings.TrimPrefix(kv, "SPRITES_TOKEN=")
+			break
+		}
+	}
+	authToken, _ := tokenFromAuthJSON(authPath)
+
+	if envToken != "" {
+		if authToken != "" && authToken != envToken {
+			return envToken, true, nil
+		}
+		return envToken, false, nil
+	}
+	if authToken != "" {
+		return authToken, false, nil
+	}
+	return "", false, errors.New("missing SPRITES_TOKEN and no token found in auth.json")
+}
+
+func tokenFromAuthJSON(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(b, &generic); err != nil {
+		return "", err
+	}
+	keys := []string{"sprites_token", "token", "access_token", "api_key"}
+	for _, k := range keys {
+		if v, ok := generic[k]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				return s, nil
+			}
+		}
+	}
+	if v, ok := generic["auth"]; ok {
+		if nested, ok := v.(map[string]any); ok {
+			for _, k := range keys {
+				if raw, ok := nested[k]; ok {
+					if s, ok := raw.(string); ok && s != "" {
+						return s, nil
+					}
+				}
+			}
+		}
+	}
+	return "", nil
+}
+
+func slugify(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+		case r == '-', r == '/', r == '.', r == '_', r == ' ':
+			b.WriteByte('-')
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+func nonEmpty(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSlugify(t *testing.T) {
+	got := slugify("Feat/My.Change Test")
+	if got != "feat-my-change-test" {
+		t.Fatalf("slugify mismatch: %q", got)
+	}
+}
+
+func TestResolveTokenPrefersEnv(t *testing.T) {
+	dir := t.TempDir()
+	authPath := filepath.Join(dir, "auth.json")
+	if err := os.WriteFile(authPath, []byte(`{"token":"from-file"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	token, warn, err := resolveToken([]string{"SPRITES_TOKEN=from-env"}, authPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "from-env" {
+		t.Fatalf("expected env token, got %q", token)
+	}
+	if !warn {
+		t.Fatal("expected warning for token mismatch")
+	}
+}
+
+func TestResolveTokenFallsBackToAuthJSON(t *testing.T) {
+	dir := t.TempDir()
+	authPath := filepath.Join(dir, "auth.json")
+	if err := os.WriteFile(authPath, []byte(`{"token":"from-file"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	token, warn, err := resolveToken(nil, authPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "from-file" {
+		t.Fatalf("expected file token, got %q", token)
+	}
+	if warn {
+		t.Fatal("did not expect mismatch warning")
+	}
+}
+
+func TestResolveTokenMissingEverywhere(t *testing.T) {
+	dir := t.TempDir()
+	authPath := filepath.Join(dir, "auth.json")
+	if err := os.WriteFile(authPath, []byte(`{"other":"value"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := resolveToken(nil, authPath)
+	if err == nil {
+		t.Fatal("expected missing token error")
+	}
+}
+
+func TestTokenFromAuthJSONNestedAuthObject(t *testing.T) {
+	dir := t.TempDir()
+	authPath := filepath.Join(dir, "auth.json")
+	if err := os.WriteFile(authPath, []byte(`{"auth":{"access_token":"nested-token"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	token, err := tokenFromAuthJSON(authPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "nested-token" {
+		t.Fatalf("expected nested token, got %q", token)
+	}
+}

--- a/internal/flow/errors.go
+++ b/internal/flow/errors.go
@@ -1,0 +1,24 @@
+package flow
+
+import (
+	"errors"
+
+	"alpine/internal/apperr"
+)
+
+func ExitCode(err error) int {
+	switch {
+	case err == nil:
+		return 0
+	case errors.Is(err, apperr.ErrUsage):
+		return 2
+	case errors.Is(err, apperr.ErrPreflight):
+		return 3
+	case errors.Is(err, apperr.ErrAuth):
+		return 4
+	case errors.Is(err, apperr.ErrCleanup):
+		return 5
+	default:
+		return 1
+	}
+}

--- a/internal/flow/errors_test.go
+++ b/internal/flow/errors_test.go
@@ -1,0 +1,27 @@
+package flow
+
+import (
+	"errors"
+	"testing"
+
+	"alpine/internal/apperr"
+)
+
+func TestExitCodeMapping(t *testing.T) {
+	tests := []struct {
+		err  error
+		want int
+	}{
+		{nil, 0},
+		{apperr.ErrUsage, 2},
+		{apperr.ErrPreflight, 3},
+		{apperr.ErrAuth, 4},
+		{apperr.ErrCleanup, 5},
+		{errors.New("other"), 1},
+	}
+	for _, tc := range tests {
+		if got := ExitCode(tc.err); got != tc.want {
+			t.Fatalf("ExitCode(%v) = %d, want %d", tc.err, got, tc.want)
+		}
+	}
+}

--- a/internal/flow/run.go
+++ b/internal/flow/run.go
@@ -1,0 +1,141 @@
+package flow
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/url"
+	"strings"
+	"time"
+
+	"alpine/internal/apperr"
+	"alpine/internal/cli"
+	"alpine/internal/remote"
+	spritesclient "alpine/internal/sprites"
+	sprites "github.com/superfly/sprites-go"
+)
+
+var adjectives = []string{"amber", "brisk", "cedar", "daring", "ember", "frosty", "golden", "hazel", "ivory", "jade", "lunar", "misty", "nimble", "ochre", "quiet", "rapid", "silver", "sunny", "vivid", "wild"}
+var nouns = []string{"badger", "canyon", "comet", "delta", "dune", "falcon", "forest", "harbor", "meadow", "mesa", "orbit", "otter", "pine", "quill", "ridge", "river", "summit", "thicket", "valley", "willow"}
+
+func Run(ctx context.Context, cfg cli.Config, stdout, stderr io.Writer) error {
+	logf(stderr, "preflight", "start", "repository=%s branch=%s", cfg.RepoName, cfg.Branch)
+
+	client := spritesclient.New(cfg.SpritesToken)
+	defer client.Close()
+
+	name, err := chooseName(ctx, client, cfg.NamePrefix)
+	if err != nil {
+		return fmt.Errorf("generate sprite name: %w", err)
+	}
+	logf(stderr, "sprite", "create", "name=%s", name)
+
+	sp, err := createWithRetry(ctx, client, name, cfg.NamePrefix)
+	if err != nil {
+		return err
+	}
+	created := true
+	cleanupOnErr := func(cause error) error {
+		if !created {
+			return cause
+		}
+		logf(stderr, "cleanup", "delete", "sprite=%s", sp.Name())
+		if delErr := client.DeleteSprite(ctx, sp.Name()); delErr != nil {
+			return fmt.Errorf("%w: %v (cleanup failed: %v)", apperr.ErrCleanup, cause, delErr)
+		}
+		return cause
+	}
+
+	logf(stderr, "bootstrap", "install", "sprite=%s", sp.Name())
+	if err := remote.Bootstrap(ctx, sp, stdout, stderr); err != nil {
+		return cleanupOnErr(err)
+	}
+
+	logf(stderr, "transfer", "start", "sprite=%s", sp.Name())
+	repoDir, err := remote.Transfer(ctx, sp, remote.TransferConfig{
+		LocalAuth:      cfg.LocalAuth,
+		LocalEnv:       cfg.LocalEnvFile,
+		LocalConfigDir: cfg.LocalConfigDir,
+		LocalClaudeDir: cfg.LocalClaudeDir,
+	})
+	if err != nil {
+		return cleanupOnErr(err)
+	}
+
+	logf(stderr, "git", "setup", "repo=%s", sanitizeRepoURL(cfg.RepoURL))
+	if err := remote.GitSetup(ctx, sp, cfg.RepoURL, repoDir, cfg.Branch, stdout, stderr); err != nil {
+		return cleanupOnErr(err)
+	}
+
+	logf(stderr, "launch", "start", "sprite_id=%s", sp.Name())
+	if err := remote.Launch(ctx, sp, repoDir, stdout, stderr); err != nil {
+		return cleanupOnErr(err)
+	}
+
+	return nil
+}
+
+func createWithRetry(ctx context.Context, client *spritesclient.Client, firstName, prefix string) (*sprites.Sprite, error) {
+	name := firstName
+	for attempt := 1; attempt <= 50; attempt++ {
+		sp, createErr := client.CreateSprite(ctx, name)
+		if createErr == nil {
+			return sp, nil
+		}
+		if !spritesclient.IsNameCollision(createErr) {
+			return nil, fmt.Errorf("create sprite: %w", createErr)
+		}
+		r := rand.New(rand.NewSource(time.Now().UnixNano() + int64(attempt)))
+		name = randomSpriteName(prefix, r)
+	}
+	return nil, fmt.Errorf("unable to create unique sprite after 50 attempts")
+}
+
+func chooseName(ctx context.Context, client *spritesclient.Client, prefix string) (string, error) {
+	existing, err := client.ListSpriteNames(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list sprites: %w", err)
+	}
+	seen := map[string]struct{}{}
+	for _, n := range existing {
+		seen[n] = struct{}{}
+	}
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 50; i++ {
+		cand := randomSpriteName(prefix, r)
+		if _, ok := seen[cand]; !ok {
+			return cand, nil
+		}
+	}
+	return "", fmt.Errorf("unable to generate a unique sprite name after 50 attempts")
+}
+
+func randomSpriteName(prefix string, r *rand.Rand) string {
+	a := adjectives[r.Intn(len(adjectives))]
+	n := nouns[r.Intn(len(nouns))]
+	if prefix == "" {
+		return a + "-" + n
+	}
+	return prefix + "-" + a + "-" + n
+}
+
+func logf(w io.Writer, phase, step, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	fmt.Fprintf(w, "phase=%s step=%s %s\n", phase, step, msg)
+}
+
+func sanitizeRepoURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err == nil && u.Scheme != "" {
+		u.User = nil
+		return strings.TrimSpace(u.String())
+	}
+	trimmed := strings.TrimSpace(raw)
+	at := strings.Index(trimmed, "@")
+	colon := strings.Index(trimmed, ":")
+	if at > 0 && colon > at {
+		return trimmed[at+1:]
+	}
+	return trimmed
+}

--- a/internal/flow/run_test.go
+++ b/internal/flow/run_test.go
@@ -1,0 +1,43 @@
+package flow
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func TestRandomSpriteNameWithPrefix(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+	name := randomSpriteName("repo-branch", r)
+	if !strings.HasPrefix(name, "repo-branch-") {
+		t.Fatalf("expected prefix, got %q", name)
+	}
+	if strings.Count(name, "-") < 3 {
+		t.Fatalf("expected adjective/noun suffix, got %q", name)
+	}
+}
+
+func TestRandomSpriteNameNoPrefix(t *testing.T) {
+	r := rand.New(rand.NewSource(2))
+	name := randomSpriteName("", r)
+	if strings.HasPrefix(name, "-") || strings.HasSuffix(name, "-") {
+		t.Fatalf("invalid name formatting: %q", name)
+	}
+	if strings.Count(name, "-") != 1 {
+		t.Fatalf("expected adjective-noun form, got %q", name)
+	}
+}
+
+func TestSanitizeRepoURLHTTPRemovesUserinfo(t *testing.T) {
+	g := sanitizeRepoURL("https://user:secret@example.com/repo.git")
+	if g != "https://example.com/repo.git" {
+		t.Fatalf("unexpected sanitized url: %s", g)
+	}
+}
+
+func TestSanitizeRepoURLScpStyleRemovesUser(t *testing.T) {
+	g := sanitizeRepoURL("git@github.com:owner/repo.git")
+	if g != "github.com:owner/repo.git" {
+		t.Fatalf("unexpected sanitized url: %s", g)
+	}
+}

--- a/internal/remote/bootstrap.go
+++ b/internal/remote/bootstrap.go
@@ -1,0 +1,138 @@
+package remote
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	sprites "github.com/superfly/sprites-go"
+)
+
+const bootstrapScript = `set -e
+opencode_bin_dir="$HOME/.opencode/bin"
+local_bin_dir="$HOME/.local/bin"
+opencode_path_line='export PATH="$HOME/.opencode/bin:$PATH"'
+local_bin_path_line='export PATH="$HOME/.local/bin:$PATH"'
+
+load_env_file() {
+  [ -f "$HOME/.env" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      ""|\#*)
+        continue
+        ;;
+      *=*)
+        key="${line%%=*}"
+        val="${line#*=}"
+        case "$key" in
+          ""|*[!A-Za-z0-9_]*)
+            continue
+            ;;
+        esac
+        export "$key=$val"
+        ;;
+    esac
+  done < "$HOME/.env"
+}
+
+mkdir -p "$local_bin_dir"
+export PATH="$local_bin_dir:$opencode_bin_dir:$PATH"
+
+if [ ! -x "$HOME/.opencode/bin/opencode" ] && ! command -v opencode >/dev/null 2>&1; then
+  tmp_installer="$(mktemp /tmp/opencode-install-XXXXXX.sh)"
+  curl -fsSL -o "$tmp_installer" https://opencode.ai/install
+  bash "$tmp_installer"
+  rm -f "$tmp_installer"
+fi
+
+install_ast_grep() {
+  if command -v ast-grep >/dev/null 2>&1 || command -v sg >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if command -v npm >/dev/null 2>&1; then
+    npm i -g @ast-grep/cli --prefix "$HOME/.local" || true
+    hash -r 2>/dev/null || true
+    if command -v ast-grep >/dev/null 2>&1 || command -v sg >/dev/null 2>&1; then
+      return 0
+    fi
+  fi
+
+  if command -v pip3 >/dev/null 2>&1; then
+    pip3 install --user ast-grep-cli || true
+    hash -r 2>/dev/null || true
+    if command -v ast-grep >/dev/null 2>&1 || command -v sg >/dev/null 2>&1; then
+      return 0
+    fi
+  fi
+
+  if command -v pip >/dev/null 2>&1; then
+    pip install --user ast-grep-cli || true
+    hash -r 2>/dev/null || true
+    if command -v ast-grep >/dev/null 2>&1 || command -v sg >/dev/null 2>&1; then
+      return 0
+    fi
+  fi
+
+  platform="$(uname -s)"
+  arch="$(uname -m)"
+  target=""
+
+  if [ "$platform" = "Linux" ]; then
+    case "$arch" in
+      x86_64|amd64) target="x86_64-unknown-linux-gnu" ;;
+      aarch64|arm64) target="aarch64-unknown-linux-gnu" ;;
+    esac
+  elif [ "$platform" = "Darwin" ]; then
+    case "$arch" in
+      x86_64|amd64) target="x86_64-apple-darwin" ;;
+      aarch64|arm64) target="aarch64-apple-darwin" ;;
+    esac
+  fi
+
+  if [ -z "$target" ]; then
+    printf "Unable to install ast-grep for %s/%s.\n" "$platform" "$arch" >&2
+    return 1
+  fi
+
+  tmp_zip="/tmp/ast-grep-$RANDOM-$RANDOM.zip"
+  curl -fsSL -o "$tmp_zip" "https://github.com/ast-grep/ast-grep/releases/latest/download/app-$target.zip"
+
+  if command -v unzip >/dev/null 2>&1; then
+    unzip -qo "$tmp_zip" -d "$local_bin_dir"
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c "import sys,zipfile; z=zipfile.ZipFile(sys.argv[1]); [z.extract(name, sys.argv[2]) for name in ('ast-grep','sg')]" "$tmp_zip" "$local_bin_dir"
+  else
+    rm -f "$tmp_zip"
+    printf "Need unzip or python3 to install ast-grep.\n" >&2
+    return 1
+  fi
+
+  rm -f "$tmp_zip"
+  chmod +x "$local_bin_dir/ast-grep" "$local_bin_dir/sg" 2>/dev/null || true
+  hash -r 2>/dev/null || true
+  command -v ast-grep >/dev/null 2>&1 || command -v sg >/dev/null 2>&1
+}
+
+install_ast_grep
+
+for rc_file in "$HOME/.zshrc" "$HOME/.zprofile" "$HOME/.bashrc" "$HOME/.profile"; do
+  [ -f "$rc_file" ] || touch "$rc_file"
+  grep -Fqx "$local_bin_path_line" "$rc_file" || printf "\n%s\n" "$local_bin_path_line" >> "$rc_file"
+  grep -Fqx "$opencode_path_line" "$rc_file" || printf "%s\n" "$opencode_path_line" >> "$rc_file"
+done
+
+load_env_file
+command -v opencode >/dev/null 2>&1
+command -v ast-grep >/dev/null 2>&1 || command -v sg >/dev/null 2>&1
+`
+
+func Bootstrap(ctx context.Context, sp *sprites.Sprite, stdout, stderr io.Writer) error {
+	cmd := sp.CommandContext(ctx, "zsh", "-lc", bootstrapScript)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("bootstrap tooling: %w", err)
+	}
+	return nil
+}

--- a/internal/remote/gitsetup.go
+++ b/internal/remote/gitsetup.go
@@ -1,0 +1,72 @@
+package remote
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	sprites "github.com/superfly/sprites-go"
+)
+
+const gitSetupScript = `set -e
+if ! command -v git >/dev/null 2>&1; then
+  printf "git is required inside sprite but was not found.\n" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$SPRITE_REPO_DIR")"
+if [ ! -d "$SPRITE_REPO_DIR/.git" ]; then
+  git clone "$SPRITE_REPO_URL" "$SPRITE_REPO_DIR"
+fi
+
+cd "$SPRITE_REPO_DIR"
+origin_url="$(git remote get-url origin 2>/dev/null || true)"
+if [ "$origin_url" != "$SPRITE_REPO_URL" ]; then
+  git remote set-url origin "$SPRITE_REPO_URL"
+fi
+
+git fetch origin --prune
+
+if git show-ref --verify --quiet "refs/heads/$SPRITE_TARGET_BRANCH"; then
+  printf "branch_path=local\n"
+  git checkout "$SPRITE_TARGET_BRANCH"
+elif git ls-remote --exit-code --heads origin "$SPRITE_TARGET_BRANCH" >/dev/null 2>&1; then
+  printf "branch_path=remote_tracking\n"
+  git checkout -b "$SPRITE_TARGET_BRANCH" --track "origin/$SPRITE_TARGET_BRANCH"
+else
+  default_remote_head="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+  if [ -n "$default_remote_head" ]; then
+    printf "branch_path=from_origin_head\n"
+    git checkout -b "$SPRITE_TARGET_BRANCH" "$default_remote_head"
+  elif git show-ref --verify --quiet refs/remotes/origin/main; then
+    printf "branch_path=from_origin_main\n"
+    git checkout -b "$SPRITE_TARGET_BRANCH" origin/main
+  elif git show-ref --verify --quiet refs/remotes/origin/master; then
+    printf "branch_path=from_origin_master\n"
+    git checkout -b "$SPRITE_TARGET_BRANCH" origin/master
+  else
+    printf "Unable to determine base branch (origin/HEAD, origin/main, origin/master).\n" >&2
+    printf "Remediation: set origin HEAD or create origin/main or origin/master, then rerun.\n" >&2
+    exit 1
+  fi
+fi
+
+if git ls-remote --exit-code --heads origin "$SPRITE_TARGET_BRANCH" >/dev/null 2>&1; then
+  git branch --set-upstream-to="origin/$SPRITE_TARGET_BRANCH" "$SPRITE_TARGET_BRANCH" >/dev/null 2>&1 || true
+fi
+`
+
+func GitSetup(ctx context.Context, sp *sprites.Sprite, repoURL, repoDir, branch string, stdout, stderr io.Writer) error {
+	cmd := sp.CommandContext(ctx, "zsh", "-lc", gitSetupScript)
+	cmd.Env = []string{
+		"SPRITE_REPO_URL=" + repoURL,
+		"SPRITE_REPO_DIR=" + repoDir,
+		"SPRITE_TARGET_BRANCH=" + branch,
+	}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git setup: %w", err)
+	}
+	return nil
+}

--- a/internal/remote/launch.go
+++ b/internal/remote/launch.go
@@ -49,7 +49,7 @@ func Launch(ctx context.Context, sp *sprites.Sprite, repoDir string, stdout, std
 	cmd := sp.CommandContext(ctx, "zsh", "-lc", launchScript)
 	cmd.Env = []string{"SPRITE_REPO_DIR=" + repoDir}
 	cmd.SetTTY(true)
-	if rows, cols, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+	if cols, rows, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
 		_ = cmd.SetTTYSize(uint16(rows), uint16(cols))
 	}
 	cmd.Stdin = os.Stdin
@@ -61,7 +61,7 @@ func Launch(ctx context.Context, sp *sprites.Sprite, repoDir string, stdout, std
 	defer signal.Stop(resize)
 	go func() {
 		for range resize {
-			if rows, cols, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+			if cols, rows, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
 				_ = cmd.SetTTYSize(uint16(rows), uint16(cols))
 			}
 		}

--- a/internal/remote/launch.go
+++ b/internal/remote/launch.go
@@ -1,0 +1,89 @@
+package remote
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	sprites "github.com/superfly/sprites-go"
+	"golang.org/x/term"
+)
+
+const launchScript = `. ~/.zprofile >/dev/null 2>&1 || true
+. ~/.zshrc >/dev/null 2>&1 || true
+if [ -f "$HOME/.env" ]; then
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      ""|\#*)
+        continue
+        ;;
+      *=*)
+        key="${line%%=*}"
+        val="${line#*=}"
+        case "$key" in
+          ""|*[!A-Za-z0-9_]*)
+            continue
+            ;;
+        esac
+        export "$key=$val"
+        ;;
+    esac
+  done < "$HOME/.env"
+fi
+cd "$SPRITE_REPO_DIR" >/dev/null 2>&1 || true
+hash -r 2>/dev/null || true
+if command -v opencode >/dev/null 2>&1; then exec opencode; fi
+exec "$HOME/.opencode/bin/opencode"`
+
+func Launch(ctx context.Context, sp *sprites.Sprite, repoDir string, stdout, stderr io.Writer) error {
+	if !isTTY() {
+		reconnect := "sprite exec -s " + shellQuote(sp.Name()) + " -tty zsh -lc " + shellQuote(launchScriptWithRepoDir(repoDir))
+		fmt.Fprintf(stdout, "status=ready\nsprite_id=%s\nreconnect=%s\n", sp.Name(), reconnect)
+		return nil
+	}
+
+	cmd := sp.CommandContext(ctx, "zsh", "-lc", launchScript)
+	cmd.Env = []string{"SPRITE_REPO_DIR=" + repoDir}
+	cmd.SetTTY(true)
+	if rows, cols, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+		_ = cmd.SetTTYSize(uint16(rows), uint16(cols))
+	}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	resize := make(chan os.Signal, 1)
+	signal.Notify(resize, syscall.SIGWINCH)
+	defer signal.Stop(resize)
+	go func() {
+		for range resize {
+			if rows, cols, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+				_ = cmd.SetTTYSize(uint16(rows), uint16(cols))
+			}
+		}
+	}()
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("launch opencode: %w", err)
+	}
+	return nil
+}
+
+func isTTY() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+func launchScriptWithRepoDir(repoDir string) string {
+	return `. ~/.zprofile >/dev/null 2>&1 || true; . ~/.zshrc >/dev/null 2>&1 || true; if [ -f "$HOME/.env" ]; then while IFS= read -r line || [ -n "$line" ]; do case "$line" in ""|\#*) continue ;; *=*) key="${line%%=*}"; val="${line#*=}"; case "$key" in ""|*[!A-Za-z0-9_]*) continue ;; esac; export "$key=$val" ;; esac; done < "$HOME/.env"; fi; cd ` + shellQuote(repoDir) + ` >/dev/null 2>&1 || true; hash -r 2>/dev/null || true; if command -v opencode >/dev/null 2>&1; then exec opencode; fi; exec "$HOME/.opencode/bin/opencode"`
+}
+
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}

--- a/internal/remote/transfer.go
+++ b/internal/remote/transfer.go
@@ -1,0 +1,271 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	sprites "github.com/superfly/sprites-go"
+)
+
+type TransferConfig struct {
+	LocalAuth      string
+	LocalEnv       string
+	LocalConfigDir string
+	LocalClaudeDir string
+}
+
+type backupEntry struct {
+	existed bool
+	data    []byte
+	mode    fs.FileMode
+}
+
+func Transfer(ctx context.Context, sp *sprites.Sprite, cfg TransferConfig) (string, error) {
+	home, err := remoteHome(ctx, sp)
+	if err != nil {
+		return "", err
+	}
+	remoteFS := sp.FilesystemAt("/")
+
+	restore := map[string]backupEntry{}
+	created := map[string]struct{}{}
+	rollback := func() {
+		for p := range created {
+			_ = remoteFS.RemoveAll(p)
+		}
+		for p, b := range restore {
+			if !b.existed {
+				_ = remoteFS.RemoveAll(p)
+				continue
+			}
+			_ = remoteFS.WriteFile(p, b.data, b.mode)
+			_ = remoteFS.Chmod(p, b.mode)
+		}
+	}
+
+	writeFileSafe := func(dst string, srcBytes []byte, mode fs.FileMode) error {
+		if err := backup(remoteFS, dst, restore); err != nil {
+			return err
+		}
+		if err := removeIfExists(remoteFS, dst); err != nil {
+			return err
+		}
+		if err := remoteFS.WriteFile(dst, srcBytes, mode); err != nil {
+			return err
+		}
+		if err := remoteFS.Chmod(dst, mode); err != nil {
+			return err
+		}
+		created[dst] = struct{}{}
+		return nil
+	}
+
+	authDst, err := safeAllowedPath(home, ".local/share/opencode/auth.json")
+	if err != nil {
+		return "", err
+	}
+	envDst, err := safeAllowedPath(home, ".env")
+	if err != nil {
+		return "", err
+	}
+	configRoot, err := safeAllowedPath(home, ".config/opencode")
+	if err != nil {
+		return "", err
+	}
+	claudeRoot, err := safeAllowedPath(home, ".claude")
+	if err != nil {
+		return "", err
+	}
+
+	authBytes, err := os.ReadFile(cfg.LocalAuth)
+	if err != nil {
+		return "", fmt.Errorf("read local auth.json: %w", err)
+	}
+	if err := writeFileSafe(authDst, authBytes, 0o600); err != nil {
+		rollback()
+		return "", fmt.Errorf("write remote auth.json: %w", err)
+	}
+
+	envBytes, err := os.ReadFile(cfg.LocalEnv)
+	if err != nil {
+		rollback()
+		return "", fmt.Errorf("read local .env: %w", err)
+	}
+	if err := writeFileSafe(envDst, envBytes, 0o600); err != nil {
+		rollback()
+		return "", fmt.Errorf("write remote .env: %w", err)
+	}
+
+	if err := copyTree(remoteFS, cfg.LocalConfigDir, configRoot, restore, created, true); err != nil {
+		rollback()
+		return "", fmt.Errorf("copy ~/.config/opencode: %w", err)
+	}
+	if err := copyTree(remoteFS, cfg.LocalClaudeDir, claudeRoot, restore, created, true); err != nil {
+		rollback()
+		return "", fmt.Errorf("copy ~/.claude: %w", err)
+	}
+
+	_ = remoteFS.Chmod(configRoot, 0o700)
+	_ = remoteFS.Chmod(claudeRoot, 0o700)
+	credPath := path.Join(claudeRoot, ".credentials.json")
+	if _, err := remoteFS.Stat(credPath); err == nil {
+		_ = remoteFS.Chmod(credPath, 0o600)
+	}
+
+	repoParent, err := safeAllowedPath(home, "code")
+	if err != nil {
+		return "", err
+	}
+	repoDir, err := safeAllowedPath(home, path.Join("code", filepath.Base(filepath.Clean(filepath.Dir(cfg.LocalEnv)))))
+	if err != nil {
+		return "", err
+	}
+	if err := remoteFS.MkdirAll(repoParent, 0o755); err != nil {
+		return "", fmt.Errorf("create remote repo parent: %w", err)
+	}
+	return repoDir, nil
+}
+
+func copyTree(remoteFS sprites.FS, srcRoot, dstRoot string, restore map[string]backupEntry, created map[string]struct{}, strictSecretMode bool) error {
+	return filepath.WalkDir(srcRoot, func(srcPath string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlinks are not allowed: %s", srcPath)
+		}
+		rel, err := filepath.Rel(srcRoot, srcPath)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "." {
+			if err := remoteFS.MkdirAll(dstRoot, 0o700); err != nil {
+				return err
+			}
+			created[dstRoot] = struct{}{}
+			return nil
+		}
+		dst, err := safeChild(dstRoot, rel)
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if err := remoteFS.MkdirAll(dst, 0o700); err != nil {
+				return err
+			}
+			created[dst] = struct{}{}
+			return nil
+		}
+
+		data, err := os.ReadFile(srcPath)
+		if err != nil {
+			return err
+		}
+		if err := backup(remoteFS, dst, restore); err != nil {
+			return err
+		}
+		if err := removeIfExists(remoteFS, dst); err != nil {
+			return err
+		}
+		mode := fs.FileMode(0o644)
+		if strictSecretMode {
+			mode = 0o600
+		}
+		if strings.HasSuffix(srcPath, ".credentials.json") {
+			mode = 0o600
+		}
+		if err := remoteFS.WriteFile(dst, data, mode); err != nil {
+			return err
+		}
+		if err := remoteFS.Chmod(dst, mode); err != nil {
+			return err
+		}
+		created[dst] = struct{}{}
+		return nil
+	})
+}
+
+func backup(remoteFS sprites.FS, dst string, store map[string]backupEntry) error {
+	if _, ok := store[dst]; ok {
+		return nil
+	}
+	st, err := remoteFS.Stat(dst)
+	if err != nil {
+		store[dst] = backupEntry{existed: false}
+		return nil
+	}
+	if st.IsDir() {
+		return errors.New("refusing to overwrite directory with file: " + dst)
+	}
+	b, err := remoteFS.ReadFile(dst)
+	if err != nil {
+		return err
+	}
+	store[dst] = backupEntry{existed: true, data: b, mode: st.Mode()}
+	return nil
+}
+
+func removeIfExists(remoteFS sprites.FS, dst string) error {
+	if _, err := remoteFS.Stat(dst); err != nil {
+		return nil
+	}
+	if err := remoteFS.Remove(dst); err != nil {
+		return err
+	}
+	return nil
+}
+
+func remoteHome(ctx context.Context, sp *sprites.Sprite) (string, error) {
+	cmd := sp.CommandContext(ctx, "sh", "-lc", "printf %s \"$HOME\"")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("resolve remote $HOME: %w", err)
+	}
+	h := strings.TrimSpace(string(out))
+	if h == "" {
+		return "", errors.New("remote HOME is empty")
+	}
+	return h, nil
+}
+
+func safeAllowedPath(home, rel string) (string, error) {
+	if strings.HasPrefix(rel, "/") {
+		return "", fmt.Errorf("absolute path not allowed: %s", rel)
+	}
+	if strings.Contains(rel, "..") {
+		return "", fmt.Errorf("path traversal rejected: %s", rel)
+	}
+	clean := path.Clean(path.Join(home, rel))
+	allowed := []string{
+		path.Join(home, ".local", "share", "opencode"),
+		path.Join(home, ".config", "opencode"),
+		path.Join(home, ".claude"),
+		path.Join(home, ".env"),
+		path.Join(home, "code"),
+	}
+	for _, base := range allowed {
+		if clean == base || strings.HasPrefix(clean, base+"/") {
+			return clean, nil
+		}
+	}
+	return "", fmt.Errorf("destination not in allowlist: %s", clean)
+}
+
+func safeChild(root, rel string) (string, error) {
+	rel = strings.TrimPrefix(rel, "./")
+	if strings.HasPrefix(rel, "/") || strings.Contains(rel, "..") {
+		return "", fmt.Errorf("invalid relative path: %s", rel)
+	}
+	out := path.Clean(path.Join(root, rel))
+	if out != root && !strings.HasPrefix(out, root+"/") {
+		return "", fmt.Errorf("symlink/path escape rejected: %s", rel)
+	}
+	return out, nil
+}

--- a/internal/remote/transfer.go
+++ b/internal/remote/transfer.go
@@ -87,10 +87,15 @@ func Transfer(ctx context.Context, sp *sprites.Sprite, cfg TransferConfig) (stri
 	if err != nil {
 		return "", fmt.Errorf("read local auth.json: %w", err)
 	}
+	authParent := path.Dir(authDst)
+	if err := remoteFS.MkdirAll(authParent, 0o700); err != nil {
+		return "", fmt.Errorf("create remote auth.json parent dir: %w", err)
+	}
 	if err := writeFileSafe(authDst, authBytes, 0o600); err != nil {
 		rollback()
 		return "", fmt.Errorf("write remote auth.json: %w", err)
 	}
+
 
 	envBytes, err := os.ReadFile(cfg.LocalEnv)
 	if err != nil {

--- a/internal/remote/transfer_test.go
+++ b/internal/remote/transfer_test.go
@@ -1,0 +1,35 @@
+package remote
+
+import "testing"
+
+func TestSafeAllowedPathRejectsTraversal(t *testing.T) {
+	if _, err := safeAllowedPath("/home/sprite", "../etc/passwd"); err == nil {
+		t.Fatal("expected traversal rejection")
+	}
+}
+
+func TestSafeChildRejectsEscape(t *testing.T) {
+	if _, err := safeChild("/home/sprite/.claude", "../../tmp/x"); err == nil {
+		t.Fatal("expected escape rejection")
+	}
+}
+
+func TestSafeAllowedPathAllowsConfiguredTargets(t *testing.T) {
+	p, err := safeAllowedPath("/home/sprite", ".config/opencode/settings.json")
+	if err != nil {
+		t.Fatalf("expected allowlisted path, got error: %v", err)
+	}
+	if p != "/home/sprite/.config/opencode/settings.json" {
+		t.Fatalf("unexpected path: %s", p)
+	}
+}
+
+func TestSafeChildAllowsNormalRelativePath(t *testing.T) {
+	p, err := safeChild("/home/sprite/.claude", "subdir/file.txt")
+	if err != nil {
+		t.Fatalf("expected safe child path, got error: %v", err)
+	}
+	if p != "/home/sprite/.claude/subdir/file.txt" {
+		t.Fatalf("unexpected path: %s", p)
+	}
+}

--- a/internal/sprites/client.go
+++ b/internal/sprites/client.go
@@ -1,0 +1,100 @@
+package spritesclient
+
+import (
+	"context"
+	"fmt"
+
+	sprites "github.com/superfly/sprites-go"
+)
+
+type Client struct {
+	sdk *sprites.Client
+}
+
+func New(token string) *Client {
+	return &Client{sdk: sprites.New(token)}
+}
+
+func (c *Client) Close() error {
+	if c == nil || c.sdk == nil {
+		return nil
+	}
+	return c.sdk.Close()
+}
+
+func (c *Client) CreateSprite(ctx context.Context, name string) (*sprites.Sprite, error) {
+	sp, err := c.sdk.CreateSprite(ctx, name, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.sdk.GetSprite(ctx, sp.Name())
+}
+
+func (c *Client) DeleteSprite(ctx context.Context, name string) error {
+	return c.sdk.DeleteSprite(ctx, name)
+}
+
+func (c *Client) ListSpriteNames(ctx context.Context) ([]string, error) {
+	all, err := c.sdk.ListAllSprites(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(all))
+	for _, sp := range all {
+		out = append(out, sp.Name())
+	}
+	return out, nil
+}
+
+func (c *Client) Sprite(name string) *sprites.Sprite {
+	return c.sdk.Sprite(name)
+}
+
+func IsNameCollision(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := fmt.Sprintf("%v", err)
+	return containsAny(s, []string{"already exists", "name is taken", "409"})
+}
+
+func containsAny(s string, parts []string) bool {
+	for _, p := range parts {
+		if p != "" && containsFold(s, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsFold(s, sub string) bool {
+	if len(sub) > len(s) {
+		return false
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if equalFoldASCII(s[i:i+len(sub)], sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func equalFoldASCII(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		ca := a[i]
+		cb := b[i]
+		if ca >= 'A' && ca <= 'Z' {
+			ca += 'a' - 'A'
+		}
+		if cb >= 'A' && cb <= 'Z' {
+			cb += 'a' - 'A'
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- Replace `setup-sprite-opencode.sh` with a parity-first Go CLI at `cmd/setup-sprite-opencode` using `sprites-go` for sprite lifecycle, remote exec, and filesystem operations.
- Add deterministic contracts for argument parsing, preflight checks, token precedence, branch validation/setup behavior, transfer safety, rollback-on-failure cleanup, and TTY/non-TTY launch output.
- Add supporting tests for exit-code mapping, config/token handling, naming, and path-safety helpers; update README usage and document migration learnings.

## Testing
- go test ./...
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/backland-labs/alpine/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
